### PR TITLE
feat: Validate feed url to no allow invalid ones

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,12 @@
 
 source 'https://rubygems.org'
 
+gem 'feedvalidator'
 gem 'graphql'
-gem 'hanami',       '~> 1.3'
-gem 'hanami-model', '~> 1.3'
+gem 'hanami',             '~> 1.3'
+gem 'hanami-model',       '~> 1.3'
+gem 'hanami-validations', '~> 1.3'
+gem 'i18n'
 gem 'pg'
 gem 'puma'
 gem 'rake'
@@ -23,4 +26,6 @@ end
 group :test do
   gem 'codecov', require: false
   gem 'rspec'
+  gem 'vcr', require: false
+  gem 'webmock', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     better_errors (2.7.0)
       coderay (>= 1.0.0)
@@ -14,6 +16,8 @@ GEM
       url
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.3.2)
@@ -55,6 +59,7 @@ GEM
       dry-logic (~> 0.4, >= 0.4.0)
       dry-types (~> 0.11.0)
     erubi (1.9.0)
+    feedvalidator (0.2.2)
     graphql (1.10.8)
     hanami (1.3.3)
       bundler (>= 1.6, < 3)
@@ -109,9 +114,12 @@ GEM
     hanami-webconsole (0.1.0)
       better_errors (~> 2.4)
       binding_of_caller (~> 0.8)
+    hashdiff (1.0.1)
     http_router (0.11.2)
       rack (>= 1.0.0)
       url_mount (~> 0.2.1)
+    i18n (1.8.3)
+      concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflecto (0.0.2)
     jaro_winkler (1.5.4)
@@ -125,6 +133,7 @@ GEM
     parser (2.7.1.2)
       ast (~> 2.4.0)
     pg (1.2.3)
+    public_suffix (4.0.5)
     puma (4.3.5)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -175,6 +184,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.10.1)
+    safe_yaml (1.0.5)
     sequel (4.49.0)
     shotgun (0.9.2)
       rack (>= 1.0)
@@ -188,6 +198,11 @@ GEM
     url (0.3.2)
     url_mount (0.2.1)
       rack
+    vcr (6.0.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -195,10 +210,13 @@ PLATFORMS
 DEPENDENCIES
   codecov
   dotenv (~> 2.4)
+  feedvalidator
   graphql
   hanami (~> 1.3)
   hanami-model (~> 1.3)
+  hanami-validations (~> 1.3)
   hanami-webconsole
+  i18n
   lefthook
   pg
   puma
@@ -206,6 +224,8 @@ DEPENDENCIES
   rspec
   rubocop
   shotgun
+  vcr
+  webmock
 
 BUNDLED WITH
    1.17.2

--- a/apps/api/mutations/add_feed.rb
+++ b/apps/api/mutations/add_feed.rb
@@ -3,6 +3,7 @@
 require_relative 'base_mutation'
 require_relative '../types/feed_input'
 require_relative '../types/feed'
+require_relative '../validators/feed_validator'
 
 module Mutations
   class AddFeed < Mutations::BaseMutation
@@ -11,9 +12,15 @@ module Mutations
     field :feed, Types::Feed, null: true
 
     def resolve(input:)
-      {
-        feed: FeedRepository.new.create(input)
-      }
+      result = Api::Validators::FeedValidator.new(input).validate
+
+      if result.success?
+        {
+          feed: FeedRepository.new.create(input)
+        }
+      else
+        raise_invalid_resource('feed', result)
+      end
     end
   end
 end

--- a/apps/api/mutations/base_mutation.rb
+++ b/apps/api/mutations/base_mutation.rb
@@ -2,5 +2,35 @@
 
 module Mutations
   class BaseMutation < GraphQL::Schema::Mutation
+    INVALID_RESOURCE = 'INVALID_RESOURCE'
+
+    def raise_invalid_resource(resource_name, result)
+      raise GraphQL::ExecutionError.new(
+        I18n.t('errors.messages.invalid_resource', resource_name: resource_name),
+        extensions: {
+          code: INVALID_RESOURCE,
+          problems: format_errors(result)
+        }.transform_keys!(&:to_s)
+      )
+    end
+
+    private
+
+    def format_errors(result)
+      messages = result.messages
+      output = result.output
+
+      messages.map do |key, value|
+        default_format(key, output[key], value.map(&:strip).join(', '))
+      end
+    end
+
+    def default_format(attribute, value, message)
+      {
+        path: [attribute.to_s],
+        explanation: "\"#{value}\" #{message}",
+        message: "\"#{value}\" #{message}"
+      }.transform_keys!(&:to_s)
+    end
   end
 end

--- a/apps/api/mutations/base_mutation.rb
+++ b/apps/api/mutations/base_mutation.rb
@@ -6,7 +6,10 @@ module Mutations
 
     def raise_invalid_resource(resource_name, result)
       raise GraphQL::ExecutionError.new(
-        I18n.t('errors.messages.invalid_resource', resource_name: resource_name),
+        I18n.t(
+          'errors.messages.invalid_resource',
+          resource_name: resource_name
+        ),
         extensions: {
           code: INVALID_RESOURCE,
           problems: format_errors(result)

--- a/apps/api/mutations/update_feed.rb
+++ b/apps/api/mutations/update_feed.rb
@@ -12,9 +12,15 @@ module Mutations
     field :feed, Types::Feed, null: true
 
     def resolve(id:, input:)
-      {
-        feed: FeedRepository.new.update(id, input)
-      }
+      result = Api::Validators::FeedValidator.new(input).validate
+
+      if result.success?
+        {
+          feed: FeedRepository.new.update(id, input)
+        }
+      else
+        raise_invalid_resource('feed', result)
+      end
     end
   end
 end

--- a/apps/api/validators/feed_validator.rb
+++ b/apps/api/validators/feed_validator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'uri'
+require 'feed_validator'
+
+module Api
+  module Validators
+    class FeedValidator
+      include Hanami::Validations
+
+      messages :i18n
+
+      HTTP_FORMAT = URI::DEFAULT_PARSER.make_regexp(%w[http https])
+
+      predicate :feed_url? do |current|
+        feed_validator = W3C::FeedValidator.new
+        feed_validator.validate_url(current)
+        feed_validator.valid?
+      end
+
+      validations do
+        required(:title) { filled? & str? }
+        required(:url) { filled? & str? & format?(HTTP_FORMAT) & feed_url? }
+        required(:kind) { filled? & str? & included_in?(FeedKind.all) }
+      end
+    end
+  end
+end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,6 +3,10 @@
 require 'bundler/setup'
 require 'hanami/setup'
 require 'hanami/model'
+require 'hanami/validations'
+
+require_relative './initializers/locale.rb'
+
 require_relative '../lib/feed_the_hungry'
 require_relative '../apps/api/application'
 

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'i18n'
+
+I18n.load_path = Dir[Hanami.root.join('config/locales/**/*.{yml,rb}')]
+I18n.default_locale = 'en'
+I18n.backend.load_translations

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,5 @@
+en:
+  errors:
+    messages:
+      invalid_resource: "The %{resource_name} is invalid"
+    feed_url?: "must be a feed url"

--- a/lib/feed_the_hungry/enumerations/feed_kind.rb
+++ b/lib/feed_the_hungry/enumerations/feed_kind.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-class FeedKind
+module FeedKind
   TEXT = 'text'
   AUDIO = 'audio'
+
+  def self.all
+    [TEXT, AUDIO]
+  end
 end

--- a/spec/api/mutations/add_feed_spec.rb
+++ b/spec/api/mutations/add_feed_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Mutations::AddFeed do
   context 'valid' do
     let(:input) do
       {
-        title: 'My feed',
+        title: 'Bruno Arueira',
         kind: FeedKind::TEXT.upcase,
-        url: 'https://myfeed.com/feed.xml'
+        url: 'https://brunoarueira.com/feed.xml'
       }
     end
 
@@ -44,28 +44,56 @@ RSpec.describe Mutations::AddFeed do
   end
 
   context 'invalid' do
-    let(:input) do
-      {
-        title: 'My feed',
-        kind: FeedKind::TEXT.upcase,
-        url: 'feed'
-      }
+    context 'url' do
+      let(:input) do
+        {
+          title: 'My feed',
+          kind: FeedKind::TEXT.upcase,
+          url: 'feed'
+        }
+      end
+
+      it 'does not create a new feed and report errors' do
+        expect(repository.all.count).to eq 0
+
+        result = Schema.execute(query, variables: variables).to_h
+
+        expect(result['errors'][0]['extensions']['problems']).to eq(
+          [{
+            'path' => ['url'],
+            'explanation' => '"feed" is not a valid URL',
+            'message' => '"feed" is not a valid URL'
+          }]
+        )
+
+        expect(repository.all.count).to eq 0
+      end
     end
 
-    it 'does not create a new feed and report errors' do
-      expect(repository.all.count).to eq 0
+    context 'feed' do
+      let(:input) do
+        {
+          title: 'My feed',
+          kind: FeedKind::TEXT.upcase,
+          url: 'https://brunoarueira.com'
+        }
+      end
 
-      result = Schema.execute(query, variables: variables).to_h
+      it 'does not create a new feed and report errors' do
+        expect(repository.all.count).to eq 0
 
-      expect(result['errors'][0]['extensions']['problems']).to eq(
-        [{
-          'path' => ['url'],
-          'explanation' => '"feed" is not a valid URL',
-          'message' => '"feed" is not a valid URL'
-        }]
-      )
+        result = Schema.execute(query, variables: variables).to_h
 
-      expect(repository.all.count).to eq 0
+        expect(result['errors'][0]['extensions']['problems']).to eq(
+          [{
+            'path' => ['url'],
+            'explanation' => '"https://brunoarueira.com" must be a feed url',
+            'message' => '"https://brunoarueira.com" must be a feed url'
+          }]
+        )
+
+        expect(repository.all.count).to eq 0
+      end
     end
   end
 end

--- a/spec/api/mutations/update_feed_spec.rb
+++ b/spec/api/mutations/update_feed_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Mutations::UpdateFeed do
       {
         title: 'My feed',
         kind: FeedKind::TEXT.upcase,
-        url: 'https://myfeed.com/feed.xml'
+        url: 'https://brunoarueira.com/feed.xml'
       }
     end
 
@@ -49,38 +49,71 @@ RSpec.describe Mutations::UpdateFeed do
       last_feed = repository.last
 
       expect(last_feed.title).to eq 'My feed'
-      expect(last_feed.url).to eq 'https://myfeed.com/feed.xml'
+      expect(last_feed.url).to eq 'https://brunoarueira.com/feed.xml'
     end
   end
 
   context 'invalid' do
-    let(:input) do
-      {
-        title: 'My feed',
-        kind: FeedKind::TEXT.upcase,
-        url: 'feed'
-      }
+    context 'url' do
+      let(:input) do
+        {
+          title: 'My feed',
+          kind: FeedKind::TEXT.upcase,
+          url: 'feed'
+        }
+      end
+
+      it 'does not update a feed with invalid input and report errors' do
+        expect(repository.all.count).to eq 1
+
+        result = Schema.execute(query, variables: variables).to_h
+
+        expect(result['errors'][0]['extensions']['problems']).to eq(
+          [{
+            'path' => ['url'],
+            'explanation' => '"feed" is not a valid URL',
+            'message' => '"feed" is not a valid URL'
+          }]
+        )
+
+        expect(repository.all.count).to eq 1
+
+        last_feed = repository.last
+
+        expect(last_feed.title).to eq 'Blog'
+        expect(last_feed.url).to eq 'https://blog.com/feed.xml'
+      end
     end
 
-    it 'does not update a feed with invalid input and report errors' do
-      expect(repository.all.count).to eq 1
+    context 'feed' do
+      let(:input) do
+        {
+          title: 'My feed',
+          kind: FeedKind::TEXT.upcase,
+          url: 'https://brunoarueira.com'
+        }
+      end
 
-      result = Schema.execute(query, variables: variables).to_h
+      it 'does not update a feed and report errors' do
+        expect(repository.all.count).to eq 1
 
-      expect(result['errors'][0]['extensions']['problems']).to eq(
-        [{
-          'path' => ['url'],
-          'explanation' => '"feed" is not a valid URL',
-          'message' => '"feed" is not a valid URL'
-        }]
-      )
+        result = Schema.execute(query, variables: variables).to_h
 
-      expect(repository.all.count).to eq 1
+        expect(result['errors'][0]['extensions']['problems']).to eq(
+          [{
+            'path' => ['url'],
+            'explanation' => '"https://brunoarueira.com" must be a feed url',
+            'message' => '"https://brunoarueira.com" must be a feed url'
+          }]
+        )
 
-      last_feed = repository.last
+        expect(repository.all.count).to eq 1
 
-      expect(last_feed.title).to eq 'Blog'
-      expect(last_feed.url).to eq 'https://blog.com/feed.xml'
+        last_feed = repository.last
+
+        expect(last_feed.title).to eq 'Blog'
+        expect(last_feed.url).to eq 'https://blog.com/feed.xml'
+      end
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/does/not_create_a_new_feed_and_report_errors.yml
+++ b/spec/fixtures/vcr_cassettes/does/not_create_a_new_feed_and_report_errors.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://validator.w3.org/feed/check.cgi?output=soap12&url=https://brunoarueira.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 18 Jul 2020 21:23:21 GMT
+      Server:
+      - Apache/2.4.38 (Debian)
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/soap+xml; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<env:Envelope xmlns:env=\"http://www.w3.org/2003/05/soap-envelope\">\n<env:Body>\n<m:feedvalidationresponse
+        env:encodingStyle=\"http://www.w3.org/2003/05/soap-encoding\" xmlns:m=\"http://www.w3.org/2005/10/feed-validator\">\n
+        \     <m:uri>https://brunoarueira.com</m:uri> \n      <m:checkedby>https://validator.w3.org/feed/check.cgi</m:checkedby>\n
+        \     <m:date>2020-07-18T21:23:21.981749</m:date>\n      <m:validity>false</m:validity>\n
+        \ <m:errors>\n        <m:errorcount>2</m:errorcount>\n        <m:errorlist><error>\n
+        \ <level>error</level>\n  <type>UndefinedElement</type>\n  <line>1</line>\n
+        \ <column>15</column>\n  <text>Undefined root element: html</text>\n  <msgcount>1</msgcount>\n
+        \ <backupcolumn>15</backupcolumn>\n  <backupline>1</backupline>\n  <element>html</element>\n
+        \ <parent>root</parent>\n</error>\n\n<error>\n  <level>error</level>\n  <type>SAXError</type>\n
+        \ <line>46</line>\n  <column>239</column>\n  <text>XML parsing error: &lt;unknown&gt;:46:239:
+        not well-formed (invalid token)</text>\n  <msgcount>1</msgcount>\n  <backupcolumn>0</backupcolumn>\n
+        \ <backupline>46</backupline>\n  <exception>&lt;unknown&gt;:46:239: not well-formed
+        (invalid token)</exception>\n</error>\n</m:errorlist>\n    </m:errors>\n    <m:warnings>\n
+        \       <m:warningcount>1</m:warningcount>\n\t<m:warninglist><warning>\n  <level>warning</level>\n
+        \ <type>UnexpectedContentType</type>\n  <text>UnexpectedContentType should
+        not be served with the &quot;text/html&quot; media type</text>\n  <contentType>text/html</contentType>\n</warning>\n</m:warninglist>\n
+        \   </m:warnings>\n    <m:informations>\n\t<m:infocount>0</m:infocount>\n\t<m:infolist></m:infolist>\n
+        \   </m:informations>\n</m:feedvalidationresponse>\n</env:Body>\n</env:Envelope>\n\n"
+  recorded_at: Sat, 18 Jul 2020 21:23:22 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/does/not_update_a_feed_and_report_errors.yml
+++ b/spec/fixtures/vcr_cassettes/does/not_update_a_feed_and_report_errors.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://validator.w3.org/feed/check.cgi?output=soap12&url=https://brunoarueira.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 18 Jul 2020 21:25:17 GMT
+      Server:
+      - Apache/2.4.38 (Debian)
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/soap+xml; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<env:Envelope xmlns:env=\"http://www.w3.org/2003/05/soap-envelope\">\n<env:Body>\n<m:feedvalidationresponse
+        env:encodingStyle=\"http://www.w3.org/2003/05/soap-encoding\" xmlns:m=\"http://www.w3.org/2005/10/feed-validator\">\n
+        \     <m:uri>https://brunoarueira.com</m:uri> \n      <m:checkedby>https://validator.w3.org/feed/check.cgi</m:checkedby>\n
+        \     <m:date>2020-07-18T21:25:17.825797</m:date>\n      <m:validity>false</m:validity>\n
+        \ <m:errors>\n        <m:errorcount>2</m:errorcount>\n        <m:errorlist><error>\n
+        \ <level>error</level>\n  <type>UndefinedElement</type>\n  <line>1</line>\n
+        \ <column>15</column>\n  <text>Undefined root element: html</text>\n  <msgcount>1</msgcount>\n
+        \ <backupcolumn>15</backupcolumn>\n  <backupline>1</backupline>\n  <element>html</element>\n
+        \ <parent>root</parent>\n</error>\n\n<error>\n  <level>error</level>\n  <type>SAXError</type>\n
+        \ <line>46</line>\n  <column>239</column>\n  <text>XML parsing error: &lt;unknown&gt;:46:239:
+        not well-formed (invalid token)</text>\n  <msgcount>1</msgcount>\n  <backupcolumn>0</backupcolumn>\n
+        \ <backupline>46</backupline>\n  <exception>&lt;unknown&gt;:46:239: not well-formed
+        (invalid token)</exception>\n</error>\n</m:errorlist>\n    </m:errors>\n    <m:warnings>\n
+        \       <m:warningcount>1</m:warningcount>\n\t<m:warninglist><warning>\n  <level>warning</level>\n
+        \ <type>UnexpectedContentType</type>\n  <text>UnexpectedContentType should
+        not be served with the &quot;text/html&quot; media type</text>\n  <contentType>text/html</contentType>\n</warning>\n</m:warninglist>\n
+        \   </m:warnings>\n    <m:informations>\n\t<m:infocount>0</m:infocount>\n\t<m:infolist></m:infolist>\n
+        \   </m:informations>\n</m:feedvalidationresponse>\n</env:Body>\n</env:Envelope>\n\n"
+  recorded_at: Sat, 18 Jul 2020 21:25:18 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/successfully/create_a_new_feed.yml
+++ b/spec/fixtures/vcr_cassettes/successfully/create_a_new_feed.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://validator.w3.org/feed/check.cgi?output=soap12&url=https://brunoarueira.com/feed.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 18 Jul 2020 21:23:22 GMT
+      Server:
+      - Apache/2.4.38 (Debian)
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/soap+xml; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<env:Envelope xmlns:env=\"http://www.w3.org/2003/05/soap-envelope\">\n<env:Body>\n<m:feedvalidationresponse
+        env:encodingStyle=\"http://www.w3.org/2003/05/soap-encoding\" xmlns:m=\"http://www.w3.org/2005/10/feed-validator\">\n
+        \     <m:uri>https://brunoarueira.com/feed.xml</m:uri> \n      <m:checkedby>https://validator.w3.org/feed/check.cgi</m:checkedby>\n
+        \     <m:date>2020-07-18T21:23:23.380706</m:date>\n      <m:validity>true</m:validity>\n
+        \ <m:errors>\n        <m:errorcount>0</m:errorcount>\n        <m:errorlist></m:errorlist>\n
+        \   </m:errors>\n    <m:warnings>\n        <m:warningcount>1</m:warningcount>\n\t<m:warninglist><warning>\n
+        \ <level>warning</level>\n  <type>MissingAtomSelfLink</type>\n  <line>30</line>\n
+        \ <column>173</column>\n  <text>Missing atom:link with rel=&quot;self&quot;</text>\n
+        \ <msgcount>1</msgcount>\n  <backupcolumn>173</backupcolumn>\n  <backupline>30</backupline>\n
+        \ <element>channel</element>\n</warning>\n</m:warninglist>\n    </m:warnings>\n
+        \   <m:informations>\n\t<m:infocount>0</m:infocount>\n\t<m:infolist></m:infolist>\n
+        \   </m:informations>\n</m:feedvalidationresponse>\n</env:Body>\n</env:Envelope>\n\n"
+  recorded_at: Sat, 18 Jul 2020 21:23:24 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/successfully/update_feed_record.yml
+++ b/spec/fixtures/vcr_cassettes/successfully/update_feed_record.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://validator.w3.org/feed/check.cgi?output=soap12&url=https://brunoarueira.com/feed.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 18 Jul 2020 21:23:24 GMT
+      Server:
+      - Apache/2.4.38 (Debian)
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/soap+xml; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<env:Envelope xmlns:env=\"http://www.w3.org/2003/05/soap-envelope\">\n<env:Body>\n<m:feedvalidationresponse
+        env:encodingStyle=\"http://www.w3.org/2003/05/soap-encoding\" xmlns:m=\"http://www.w3.org/2005/10/feed-validator\">\n
+        \     <m:uri>https://brunoarueira.com/feed.xml</m:uri> \n      <m:checkedby>https://validator.w3.org/feed/check.cgi</m:checkedby>\n
+        \     <m:date>2020-07-18T21:23:25.351203</m:date>\n      <m:validity>true</m:validity>\n
+        \ <m:errors>\n        <m:errorcount>0</m:errorcount>\n        <m:errorlist></m:errorlist>\n
+        \   </m:errors>\n    <m:warnings>\n        <m:warningcount>1</m:warningcount>\n\t<m:warninglist><warning>\n
+        \ <level>warning</level>\n  <type>MissingAtomSelfLink</type>\n  <line>30</line>\n
+        \ <column>173</column>\n  <text>Missing atom:link with rel=&quot;self&quot;</text>\n
+        \ <msgcount>1</msgcount>\n  <backupcolumn>173</backupcolumn>\n  <backupline>30</backupline>\n
+        \ <element>channel</element>\n</warning>\n</m:warninglist>\n    </m:warnings>\n
+        \   <m:informations>\n\t<m:infocount>0</m:infocount>\n\t<m:infolist></m:infolist>\n
+        \   </m:informations>\n</m:feedvalidationresponse>\n</env:Body>\n</env:Envelope>\n\n"
+  recorded_at: Sat, 18 Jul 2020 21:23:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'vcr'
+
+VCR.configure do |config|
+  config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  config.hook_into :webmock
+end
+
+RSpec.configure do |config|
+  # Add VCR to all tests
+  config.around(:each) do |example|
+    options = example.metadata[:vcr] || {}
+    if options[:record] == :skip
+      VCR.turned_off(&example)
+    else
+      name = example
+             .metadata[:description]
+             .split(/\s+/, 2)
+             .join('/')
+             .downcase
+             .gsub(/\./, '/')
+             .gsub(%r{[^\w/]+}, '_')
+             .gsub(%r{/$}, '')
+      VCR.use_cassette(name, record: :once, &example)
+    end
+  end
+end


### PR DESCRIPTION
The validation is based on W3C that can be accessed here https://validator.w3.org/feed/, this project though use a gem which uses an API approach served by the W3C using SOAP.

Fixes #22 