### PR TITLE
chore: Optimizes docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.env.*
+.git
+.github
+coverage
+env
+log
+README.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app: &app
     build:
       context: .
-    image: fth-backend:1.0.1
+    image: fth-backend:1.0.2
 
   backend: &backend
     <<: *app


### PR DESCRIPTION
Greatly reduced from the previous version 1.0.1 with 721MB to 1.0.2 on 575MB, maybe there is more improvements to do.

```
❯ docker image ls | grep fth
fth-backend                   1.0.2          94abe3997296   6 minutes ago       575MB
fth-backend                   1.0.1          8fdf32fb6d50   31 minutes ago      721MB
fth-backend                   1.0.0          b340532d4df3   2 weeks ago         700MB
```